### PR TITLE
use finally to ensure hooks are cleaned up

### DIFF
--- a/torchsummaryX/torchsummaryX.py
+++ b/torchsummaryX/torchsummaryX.py
@@ -78,10 +78,11 @@ def summary(model, x, *args, **kwargs):
     model.apply(register_hook)
 
     with torch.no_grad():
-        model(x) if not (kwargs or args) else model(x, *args, **kwargs)
-
-    for hook in hooks:
-        hook.remove()
+        try:
+            model(x) if not (kwargs or args) else model(x, *args, **kwargs)
+        finally:
+            for hook in hooks:
+                hook.remove()
 
     # Use pandas to align the columns
     df = pd.DataFrame(summary).T


### PR DESCRIPTION
The try-finally construct guarantees that the “remove hooks” part is always executed, even if the code that does the work doesn’t finish.