### PR TITLE
fix pandas package feature warning (issue #19)

### DIFF
--- a/torchsummaryX/torchsummaryX.py
+++ b/torchsummaryX/torchsummaryX.py
@@ -110,7 +110,7 @@ def summary(model, x, *args, layer_modules=layer_modules, print_summary=True, **
         ksize="Kernel Shape",
         out="Output Shape",
     ))
-    df_sum = df.sum()
+    df_sum = df[["params_nt", "Mult-Adds", "Params", "Non-trainable params"]].sum()
     df.index.name = "Layer"
 
     df = df[["Kernel Shape", "Output Shape", "Params", "Mult-Adds"]]


### PR DESCRIPTION
Issue #19 reported a feature warning while using pandas package. The details can be found at (https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.3.0.html#deprecations).
To sum up, users need to select only valid columns before calling the reduction function (e.g. .min, .max, .sum) on a DataFrame.
So, in line 113 "df_sum = df.sum()" is replaced with "df_sum = df[["params_nt", "Mult-Adds", "Params", "Non-trainable params"]].sum()".
This columns are useful to show the final table of network's information.
Without redundant .sum() caculations on other columns, very very little time also can be saved : )